### PR TITLE
Fix header values to be strings instead of boolean

### DIFF
--- a/taiga/requestmaker.py
+++ b/taiga/requestmaker.py
@@ -66,7 +66,7 @@ class RequestMaker(object):
         headers = {
             'Content-type': 'application/json',
             'Authorization': '{0} {1}'.format(self.token_type, self.token),
-            'x-disable-pagination': True
+            'x-disable-pagination': 'True'
         }
         return headers
 


### PR DESCRIPTION
Changed header value of RequestMaker 'x-disable-pagination' header to be a string instead of boolean since the requests library enforces string (or binary) values for headers only and raises an exception since version 2.11.0.
